### PR TITLE
買い目選択にワイドを追加

### DIFF
--- a/software/random_horse_racing_bets/index.html
+++ b/software/random_horse_racing_bets/index.html
@@ -17,31 +17,31 @@
     <div>
       <h2>出走頭数</h2>
       <select id="number_of_runners">
-        <option value="2">2</option>
-        <option value="3">3</option>
-        <option value="4">4</option>
-        <option value="5">5</option>
-        <option value="6">6</option>
-        <option value="7">7</option>
-        <option value="8">8</option>
-        <option value="9">9</option>
-        <option value="10">10</option>
-        <option value="11">11</option>
-        <option value="12">12</option>
-        <option value="13">13</option>
-        <option value="14">14</option>
-        <option value="15">15</option>
-        <option value="16">16</option>
-        <option value="17">17</option>
-        <option value="18">18</option>
+        <option id="number_2" value="2">2</option>
+        <option id="number_3" value="3">3</option>
+        <option id="number_4" value="4">4</option>
+        <option id="number_5" value="5">5</option>
+        <option id="number_6" value="6">6</option>
+        <option id="number_7" value="7">7</option>
+        <option id="number_8" value="8">8</option>
+        <option id="number_9" value="9">9</option>
+        <option id="number_10" value="10">10</option>
+        <option id="number_11" value="11">11</option>
+        <option id="number_12" value="12">12</option>
+        <option id="number_13" value="13">13</option>
+        <option id="number_14" value="14">14</option>
+        <option id="number_15" value="15">15</option>
+        <option id="number_16" value="16">16</option>
+        <option id="number_17" value="17">17</option>
+        <option id="number_18" value="18">18</option>
       </select>
     </div>
     <div>
       <h2>買い方</h2>
       <select id="how_to_buy">
-        <option value="単勝">単勝</option>
-        <option value="複勝">複勝</option>
-        <option value="ワイド">ワイド</option>
+        <option id="winning_bets" value="単勝">単勝</option>
+        <option id="placing_bets" value="複勝">複勝</option>
+        <option id="wide" value="ワイド">ワイド</option>
         <!--
         <option value="枠連">枠連</option>
         <option value="馬連">馬連</option>

--- a/software/random_horse_racing_bets/js/bets.js
+++ b/software/random_horse_racing_bets/js/bets.js
@@ -1,19 +1,20 @@
 const outputButton = document.getElementById('output_button');
 const resultHowToBuy = document.getElementById('result_how_to_buy');
 const resultBettingNumber = document.getElementById('result_betting_number');
+const numberOfRunners = document.getElementById('number_of_runners');
+const selectedWide = document.getElementById('wide');
+const howToBuy = document.getElementById('how_to_buy');
 
 function bettingSelectionsOutput() {
-  const numberOfRunners = document.getElementById('number_of_runners').value;
-  const howToBuy = document.getElementById('how_to_buy').value;
 
-  resultHowToBuy.textContent = howToBuy;
-  if (howToBuy == "単勝" || howToBuy == "複勝") {
-    resultBettingNumber.textContent = Math.floor(Math.random() * numberOfRunners) + 1;
-  } else if (howToBuy == "ワイド") {
-    let countArray = Array.from({ length: numberOfRunners }, (v, i) => i+1);
-    let picks = [];
+  resultHowToBuy.textContent = howToBuy.value;
+  if (howToBuy.value == "単勝" || howToBuy.value == "複勝") {
+    resultBettingNumber.textContent = Math.floor(Math.random() * numberOfRunners.value) + 1;
+  } else if (howToBuy.value == "ワイド") {
+    const countArray = Array.from({ length: numberOfRunners.value }, (v, i) => i+1);
+    const picks = [];
     for (let i = 0; i < 3; i++) {
-      let selectedIndex = Math.floor(Math.random() * countArray.length);
+      const selectedIndex = Math.floor(Math.random() * countArray.length);
       picks.push(countArray[selectedIndex]);
       countArray.splice(selectedIndex, 1);
     }
@@ -26,4 +27,16 @@ function compareNumbers(a, b) {
   return a - b;
 }
 
+function changeRunners() {
+  const number2 = document.getElementById("number_2");
+
+  if (howToBuy.value == "ワイド") {
+    number2.style.display = "none";
+    numberOfRunners.value = numberOfRunners.value == "2" ? "3" : numberOfRunners.value;
+  } else {
+    number2.style.display = "block";
+  }
+}
+
 outputButton.addEventListener("click", bettingSelectionsOutput);
+howToBuy.addEventListener("change", changeRunners);


### PR DESCRIPTION
# 内容
買い方に「ワイド」を追加。
# 実装処理
## index.html
- selectの各optionにidを付与
- 買い方のワイドを追加(コメントアウト除外)
## bet.js
- bettingSelectionsOutputにワイド専用の処理を追加
- compareNumbers関数を追加(出力する番号を昇順に変更)
- changeRunners関数を追加(ワイドを選択する時、出走頭数の"2"を非表示＆単数か複勝を選択時、"2"を表示)